### PR TITLE
Update black target version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 80
-target-version = ['py37']
+target-version = ['py39']

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ mypy
 docformatter
 pre-commit
 pydocstyle==6.1.1
+toml


### PR DESCRIPTION
The file pyproject.toml should stay. See PEP [518](https://peps.python.org/pep-0518/) for more information.
Fixes #9